### PR TITLE
Reduce workflows run time

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,5 +23,3 @@ jobs:
         restore-keys: ${{ matrix.os }}-m2
     - name: Test Qme5
       run: mvn test
-    - name: Build Qme5
-      run: mvn -B package --file pom.xml


### PR DESCRIPTION
In this pr I was originally going to setup tests for macos and windows but as turns out macos takes about 3 times as long to finish and costs 10 times more in minutes and windows is pretty much identical to Linux so I don't see any reason to test there.

The most important thing I added was dependency caching for maven so tests won't need to download dependencies each time which cuts down a ton on runtime.