### PR TITLE
Change java version 16 back to 15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>0.4.0</version>
 
     <properties>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
+        <maven.compiler.source>15</maven.compiler.source>
+        <maven.compiler.target>15</maven.compiler.target>
         <lwjgl.version>3.2.3</lwjgl.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -329,8 +329,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>15</source>
+                    <target>15</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
- We will likely change back to 16 because it is EOL but in the mean
time we still want 15 because it's already installed open peoples
machines and we don't wanna break things